### PR TITLE
Add path argument. Fix PEP8 violations.

### DIFF
--- a/main.py
+++ b/main.py
@@ -3,25 +3,40 @@ import os
 import argparse
 import sys
 
-parser = argparse.ArgumentParser(description='Download assets from Modpacks.ch')
-parser.add_argument( '-u', '--url', type=str,
-                    help='Download files from URL.')
-args = parser.parse_args()
 
-if len(sys.argv) == 1:
-    parser.print_help()
-    sys.exit(0)
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description='Download assets from Modpacks.ch')
+    parser.add_argument('-u', '--url', type=str, required=True,
+                        help='Download files from URL.')
+    parser.add_argument('-p', '--path', type=str, default=os.getcwd(),
+                        help="Path to place downloads. Defaults to current directory.")
+    args = parser.parse_args()
+    go_to_path(args, parser)
+    return args
+
+
+def go_to_path(args, parser):
+    try:
+        os.chdir(args.path)
+    except:
+        print(f"ERROR: Cannot go to path {args.path}!")
+        parser.print_help()
+        sys.exit(1)
+
 
 def download_manifest(url):
-  r = requests.get(url)
-  json = r.json()
-  for file in json['files']:
-    if not file['path'] == './':
-      if not os.path.isdir(file['path'][2:]):
-        os.makedirs(file['path'][2:])
-    file_content = requests.get(file['url']).content
-    with open(file['path'][2:] + file['name'], 'wb') as f:
-      f.write(file_content)
-    print('Downloaded: {}!'.format(file['path'][2:] + file['name']))
+    r = requests.get(url)
+    json = r.json()
+    for file in json['files']:
+        if not file['path'] == './':
+            if not os.path.isdir(file['path'][2:]):
+                os.makedirs(file['path'][2:])
+        file_content = requests.get(file['url']).content
+        with open(file['path'][2:] + file['name'], 'wb') as f:
+            f.write(file_content)
+        print('Downloaded: {}!'.format(file['path'][2:] + file['name']))
 
-download_manifest(args.url)
+
+if __name__ == "__main__":
+    download_manifest(parse_args().url)


### PR DESCRIPTION
I saw your [FTB Reddit post](https://www.reddit.com/r/feedthebeast/comments/i9clsj/mchdl_a_simple_command_line_ftb_app_alternative/) and I found that it was difficult to work with this script when my server was in another directory. So I quickly added a path argument.

I also changed spacing from two to four to follow PEP8 guidelines. That can be removed if you don't like it.